### PR TITLE
Fix log level preventing reveal and open operations #43

### DIFF
--- a/dataans/src-tauri/src/config.rs
+++ b/dataans/src-tauri/src/config.rs
@@ -77,7 +77,8 @@ pub fn open_config_file(app_handle: AppHandle) {
 
     let config_file_path = configs_dir.join(CONFIG_FILE_NAME);
 
-    info!(open_config_file_result = ?opener::open(&config_file_path));
+    let open_config_file_result = opener::open(&config_file_path);
+    info!(?open_config_file_result);
 }
 
 #[tauri::command]
@@ -90,7 +91,8 @@ pub fn open_theme_file(app_handle: AppHandle, file_path: PathBuf) {
 
     let theme_file_path = configs_dir.join(file_path);
 
-    info!(open_config_file_result = ?opener::reveal(&theme_file_path));
+    let open_theme_file_result = opener::open(&theme_file_path);
+    info!(?open_theme_file_result);
 }
 
 #[tauri::command]
@@ -103,17 +105,20 @@ pub fn open_config_file_folder(app_handle: AppHandle) {
 
     let config_file_path = configs_dir.join(CONFIG_FILE_NAME);
 
-    info!(open_config_file_folder_result = ?opener::reveal(&config_file_path));
+    let open_config_file_folder_result = opener::reveal(&config_file_path);
+    info!(?open_config_file_folder_result);
 }
 
 #[instrument]
 #[tauri::command]
 pub fn reveal(path: PathBuf) {
-    info!(reveal_note_file_result = ?opener::reveal(&path));
+    let reveal_note_file_result = opener::reveal(&path);
+    info!(?reveal_note_file_result);
 }
 
 #[instrument]
 #[tauri::command]
 pub fn open(path: PathBuf) {
-    info!(open_note_file_result = ?opener::open(&path));
+    let open_note_file_result = opener::open(&path);
+    info!(?open_note_file_result);
 }


### PR DESCRIPTION
This fixes the issue where opener::open() and opener::reveal() would not work in config.rs if `tracing::info!` log level is filtered out on stricter log levels (`warn`, `error` - and `error` is default).

Also added explicit default log level (your call whether you like this change or not).

Closes #43