### PR TITLE
Focus app window on its reopening

### DIFF
--- a/dataans/src-tauri/src/main.rs
+++ b/dataans/src-tauri/src/main.rs
@@ -43,6 +43,7 @@ fn toggle_app_visibility(app: &AppHandle) -> Result<()> {
         } else {
             info!("Show main window");
             window.show()?;
+            window.set_focus()?;
             item_handle.set_title(WINDOW_HIDE_TITLE)?;
         }
     } else {


### PR DESCRIPTION
Sometimes, if you toggle the app window visibility, it can not appear at the front and you need to select the window from the taskbar anyway.
This PR fixes this behavior (at least, I cannot reproduce it) by setting the focus on the app window.