### PR TITLE
Fix scrollbar overlap with the code block element

### DIFF
--- a/dataans/public/css/layout.css
+++ b/dataans/public/css/layout.css
@@ -72,7 +72,8 @@ h4 {
 }
 
 ::-webkit-scrollbar {
-    width: 8px;
+    width: 0.6em;
+    height: 0.6em;
     border-radius: 3px;
 }
 

--- a/dataans/src/notes/md_node/code_block.rs
+++ b/dataans/src/notes/md_node/code_block.rs
@@ -1,3 +1,4 @@
+use leptos::html;
 use leptos::prelude::*;
 
 use crate::backend::parse_code;
@@ -12,6 +13,15 @@ pub fn CodeBlock(code: String, lang: String) -> impl IntoView {
         let code_value = code_value.clone();
         let lang = language.clone();
         async move { parse_code(&lang, &code_value).await.unwrap_or(code_value.clone()) }
+    });
+
+    let code_container_ref = NodeRef::<html::Div>::new();
+
+    Effect::new(move || {
+        highlighted_code.get();
+        if let Some(code_container) = code_container_ref.get() {
+            let _ = code_container.scroll_height();
+        }
     });
 
     let code_value = code.clone();
@@ -35,14 +45,21 @@ pub fn CodeBlock(code: String, lang: String) -> impl IntoView {
                     <img alt="copy code" src="/public/icons/copy-dark.png" />
                 </button>
             </div>
-            <Suspense
-                fallback=move || view! { <span>"Parsing code...."</span> }
-            >
-                {move || highlighted_code.get()
-                    .map(|inner_html| view! {
-                        <div class="code-block-wrapper" inner_html=inner_html />
-                    })}
-            </Suspense>
+            <div class="code-block-wrapper" node_ref=code_container_ref>
+                <Suspense
+                    fallback=move || view! { <span>"Parsing code...."</span> }
+                >
+                    {move || highlighted_code.get()
+                        .map(|inner_html| {
+                            let mut code = Dom::create_element_from_html(inner_html.into());
+                            code.mount(&code_container_ref.get().expect("code container should be mounted"), None);
+
+                            view! {
+                                <span />
+                            }
+                        })}
+                </Suspense>
+            </div>
         </div>
     }
 }


### PR DESCRIPTION
Some time ago, I noticed that the scrollbar can overlap with the code block element when the code contains very wide lines. Especially, it was noticed in one-line code blocks:

|before|after|
|-|-|
| <img width="698" height="139" alt="image" src="https://github.com/user-attachments/assets/94b201c7-6637-46b4-b16f-14e13c861ce3" /> | <img width="678" height="139" alt="image" src="https://github.com/user-attachments/assets/6b9cdc01-5c79-4d7f-acce-b9af18412f73" /> |

The problem was in the way it sets the highlighted code HTML. Previously, it used to use the `inner_html` attribute. But, as you can see, it has flows. Inserting raw HTML does not trigger the page layout recalculation (reflow). So, I implemented it via `element.scroll_height()`.

Surprisingly, it did not help. After many unsuccessful tries, I decided to replace raw HTML injection with the `Dom::create_element_from_html` function and then mounting ([`Mountable::mound`](https://docs.rs/leptos/latest/leptos/prelude/trait.Mountable.html#tymethod.mount)) the created element. Fortunately, it worked.

Then, I thought that I could get rid of the `<Suspense />` component and make it using a simple `mode || if {} else {}`. Surprisingly, the fix stopped working when I refactored the code :thinking: :fearful:. I do not know why. I have a few theories, but I have not tested them. I decided to leave it as it is.

I hate frontend because of such bugs (but I do not blame anyone).