### PR TITLE
feat(front): implement list autocontinue when typing a new line;

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1936,6 +1936,7 @@ dependencies = [
  "leptos_router",
  "log",
  "markdown",
+ "regex",
  "serde",
  "serde-wasm-bindgen",
  "time",
@@ -2155,7 +2156,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
- "libloading 0.7.4",
+ "libloading 0.8.8",
 ]
 
 [[package]]
@@ -4344,7 +4345,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -6259,9 +6260,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/dataans/Cargo.toml
+++ b/dataans/Cargo.toml
@@ -47,3 +47,4 @@ web-sys = { version = "0.3", features = [
     "HtmlElement",
     "HtmlSelectElement",
 ] }
+regex = "1.11.2"


### PR DESCRIPTION
closes #64 

This PR implements automatic list incrementing when typing a new line. It works for both types of lists: unordered and ordered.

There is a small limitation: **list items must be one-line text**. If the list item consists of more than one line of text, then it will not work. It is done on purpose. It is hard to parse the previous list item. It can be just text, or any other Markdown component (table, code block, etc.). We do not want to do MD parsing on the frontend.

The primary purpose of this feature is to assist users in the most common scenarios when writing lists.