### PR TITLE
Fix synchronization algorithm in many places

### DIFF
--- a/crates/web-server/src/db/mod.rs
+++ b/crates/web-server/src/db/mod.rs
@@ -12,6 +12,9 @@ pub enum DbError {
 
     #[error("{0} operation is unsupported")]
     Unsupported(&'static str),
+
+    #[error("invalid operation: {0}")]
+    InvalidOperation(&'static str),
 }
 
 pub trait OperationsDb: Send + Sync {

--- a/crates/web-server/src/db/postgres.rs
+++ b/crates/web-server/src/db/postgres.rs
@@ -1,4 +1,5 @@
-use sqlx::PgPool;
+use sqlx::{PgConnection, PgPool};
+use uuid::Uuid;
 
 use super::model::*;
 use super::{DbError, OperationsDb};
@@ -13,11 +14,22 @@ impl PostgresDb {
     }
 }
 
+impl PostgresDb {
+    async fn operation_by_id(&self, operation_id: Uuid, connection: &mut PgConnection) -> Result<Operation, DbError> {
+        let operation = sqlx::query_as("select id, created_at, data, checksum from operation where id = $1")
+            .bind(operation_id)
+            .fetch_one(&mut *connection)
+            .await?;
+
+        Ok(operation)
+    }
+}
+
 impl OperationsDb for PostgresDb {
     async fn operations(&self, operations_to_skip: usize) -> Result<Vec<Operation>, DbError> {
         let operations =
             sqlx::query_as("select id, created_at, data, checksum from operation order by created_at offset $1")
-                .bind(i64::try_from(operations_to_skip).expect("usize -> u32 conversion should not fail"))
+                .bind(i64::try_from(operations_to_skip).expect("usize -> i64 conversion should not fail"))
                 .fetch_all(&self.pool)
                 .await?;
 
@@ -29,22 +41,40 @@ impl OperationsDb for PostgresDb {
 
         // TODO: replace with `join_all`.
         for operation in operations {
-            let Operation {
-                id,
-                created_at,
-                data,
-                checksum,
-            } = operation;
+            if let Ok(existing_operation) = self.operation_by_id(operation.id, &mut transaction).await {
+                warn!(
+                    "Operation ({}) reuploading detected. It is allowed but unwanted behaviour!",
+                    operation.id
+                );
 
-            sqlx::query!(
-                "insert into operation (id, created_at, data, checksum) values ($1, $2, $3, $4)",
-                id,
-                created_at,
-                data,
-                checksum
-            )
-            .execute(&mut *transaction)
-            .await?;
+                if existing_operation.checksum != operation.checksum {
+                    error!(
+                        "Operation with id ({}) always exists but provided operation checksum ({:?}) do not match existing operation checksum ({:?}).",
+                        operation.id, operation.checksum, existing_operation.checksum
+                    );
+
+                    return Err(DbError::InvalidOperation(
+                        "operation with the same id but different checksum already exists",
+                    ));
+                }
+            } else {
+                let Operation {
+                    id,
+                    created_at,
+                    data,
+                    checksum,
+                } = operation;
+
+                sqlx::query!(
+                    "insert into operation (id, created_at, data, checksum) values ($1, $2, $3, $4)",
+                    id,
+                    created_at,
+                    data,
+                    checksum
+                )
+                .execute(&mut *transaction)
+                .await?;
+            }
         }
 
         transaction.commit().await?;

--- a/crates/web-server/src/main.rs
+++ b/crates/web-server/src/main.rs
@@ -106,14 +106,9 @@ async fn main() -> std::result::Result<(), Box<rocket::Error>> {
         .manage(state)
         .mount(
             "/data",
-            routes![
-                routes::blocks,
-                routes::operations,
-                routes::add_operations,
-                routes::exists,
-            ],
+            routes![routes::blocks, routes::operations, routes::add_operations,],
         )
-        .mount("/file", routes![routes::upload, routes::download])
+        .mount("/file", routes![routes::upload, routes::download, routes::exists,])
         .mount(
             "/health",
             routes![routes::health, routes::health_auth, routes::cf_token],

--- a/crates/web-server/src/main.rs
+++ b/crates/web-server/src/main.rs
@@ -106,7 +106,12 @@ async fn main() -> std::result::Result<(), Box<rocket::Error>> {
         .manage(state)
         .mount(
             "/data",
-            routes![routes::blocks, routes::operations, routes::add_operations,],
+            routes![
+                routes::blocks,
+                routes::operations,
+                routes::add_operations,
+                routes::exists,
+            ],
         )
         .mount("/file", routes![routes::upload, routes::download])
         .mount(

--- a/crates/web-server/src/routes/file.rs
+++ b/crates/web-server/src/routes/file.rs
@@ -1,5 +1,6 @@
 use rocket::data::{Data, ToByteUnit};
 use rocket::http::{ContentType, Header, Status};
+use rocket::serde::json::Json;
 use rocket::{Response, State, get, post};
 use uuid::Uuid;
 use web_api_types::Result;
@@ -13,6 +14,11 @@ pub async fn upload(_u: UserContext, server: &State<WebServerState>, id: Uuid, d
     server.file_saver.save_file(id, data.open(2.gigabytes())).await?;
 
     Ok(())
+}
+
+#[get("/<id>/exists")]
+pub async fn exists(_u: UserContext, server: &State<WebServerState>, id: Uuid) -> Result<Json<bool>> {
+    Ok(Json(server.file_saver.exists(id).await?))
 }
 
 pub struct Resp<'r>(Response<'r>);

--- a/dataans/src-tauri/src/dataans/db/model/operation.rs
+++ b/dataans/src-tauri/src/dataans/db/model/operation.rs
@@ -28,7 +28,7 @@ use crate::dataans::sync::{Hash, Hasher};
 /// The user's operation type (and its data).
 ///
 /// This enumeration lists all possible user operation types.
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
 pub enum Operation<'data> {
     CreateNote(Cow<'data, Note>),
     UpdateNote(Cow<'data, Note>),
@@ -362,7 +362,7 @@ impl Hash for Operation<'_> {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
 pub struct OperationRecord<'data> {
     pub id: Uuid,
     #[serde(with = "rfc3339")]

--- a/dataans/src-tauri/src/dataans/db/model/operation.rs
+++ b/dataans/src-tauri/src/dataans/db/model/operation.rs
@@ -193,7 +193,7 @@ impl Operation<'_> {
                 // operations uploading succeeded, or when two sync processes happened concurrently.
                 // file.is_uploaded = true;
 
-                SqliteDb::add_file(&file, operation_time, transaction).await?;
+                SqliteDb::add_file(file, operation_time, transaction).await?;
 
                 let File {
                     id,

--- a/dataans/src-tauri/src/dataans/db/model/operation.rs
+++ b/dataans/src-tauri/src/dataans/db/model/operation.rs
@@ -120,7 +120,7 @@ impl Operation<'_> {
                 }))
             }
             Operation::UpdateNote(note) => {
-                let local_note = SqliteDb::note_by_id(note.id, transaction.as_mut()).await?;
+                let local_note = SqliteDb::absolute_note_by_id(note.id, transaction.as_mut()).await?;
 
                 if local_note.updated_at < operation_time {
                     SqliteDb::update_note(note.as_ref(), operation_time, transaction).await?;
@@ -173,7 +173,7 @@ impl Operation<'_> {
                 }
             }
             Operation::DeleteNote(id) => {
-                let local_note = SqliteDb::note_by_id(*id, transaction.as_mut()).await?;
+                let local_note = SqliteDb::absolute_note_by_id(*id, transaction.as_mut()).await?;
 
                 if local_note.updated_at < operation_time {
                     SqliteDb::remove_note_inner(*id, operation_time, transaction).await?;
@@ -213,7 +213,7 @@ impl Operation<'_> {
                 }))
             }
             Operation::DeleteFile(id) => {
-                let local_file = SqliteDb::file_by_id(*id, transaction.as_mut()).await?;
+                let local_file = SqliteDb::absolute_file_by_id(*id, transaction.as_mut()).await?;
 
                 if local_file.updated_at < operation_time {
                     SqliteDb::remove_file(*id, operation_time, transaction).await?;
@@ -244,7 +244,7 @@ impl Operation<'_> {
                 }))
             }
             Operation::UpdateSpace(space) => {
-                let local_space = SqliteDb::space_by_id(space.id, transaction.as_mut()).await?;
+                let local_space = SqliteDb::absolute_space_by_id(space.id, transaction.as_mut()).await?;
 
                 if local_space.updated_at < operation_time {
                     SqliteDb::update_space(space.as_ref(), operation_time, transaction).await?;
@@ -272,7 +272,7 @@ impl Operation<'_> {
                 }
             }
             Operation::DeleteSpace(id) => {
-                let local_space = SqliteDb::space_by_id(*id, transaction.as_mut()).await?;
+                let local_space = SqliteDb::absolute_space_by_id(*id, transaction.as_mut()).await?;
 
                 if local_space.updated_at < operation_time {
                     SqliteDb::remove_space(*id, operation_time, transaction).await?;

--- a/dataans/src-tauri/src/dataans/db/model/operation.rs
+++ b/dataans/src-tauri/src/dataans/db/model/operation.rs
@@ -187,10 +187,10 @@ impl Operation<'_> {
                 }
             }
             Operation::CreateFile(file) => {
-                // The commented line below is a bug. Previously, we assumed that when we accept `CreateFile` operation,
-                // than it also means that the file is also uploaded. But it not necessarily true. The operation can be synced
-                // with the server before the actual file upload happens. For example, when the file uploading failed but
-                // operations uploading succeeded, or when two sync processes happened concurrently.
+                // The commented line below is a bug. Previously, we assumed that when we accept the `CreateFile` operation,
+                // it also means that the file is uploaded. But it is not necessarily true. The operation can be synced with
+                // the server before the actual file upload happens. For example, when the file uploading failed but the operations
+                // uploading succeeded, or when two sync processes happened concurrently.
                 // file.is_uploaded = true;
 
                 SqliteDb::add_file(file, operation_time, transaction).await?;

--- a/dataans/src-tauri/src/dataans/db/sqlite.rs
+++ b/dataans/src-tauri/src/dataans/db/sqlite.rs
@@ -62,6 +62,20 @@ impl SqliteDb {
         Ok(())
     }
 
+    /// Returns the space by its id.
+    ///
+    /// The same as [SqliteDb::space_by_id] but returns the space even if deleted.
+    pub async fn absolute_space_by_id(space_id: Uuid, connection: &mut SqliteConnection) -> Result<Space, DbError> {
+        let space =
+            sqlx::query_as("SELECT id, name, avatar_id, created_at, updated_at, is_deleted FROM spaces WHERE id = ?1")
+                .bind(space_id)
+                .fetch_one(&mut *connection)
+                .await?;
+
+        Ok(space)
+    }
+
+    /// Returns the space by its id. Returns an error if the space is deleted.
     pub async fn space_by_id(space_id: Uuid, connection: &mut SqliteConnection) -> Result<Space, DbError> {
         let space = sqlx::query_as("SELECT id, name, avatar_id, created_at, updated_at, is_deleted FROM spaces WHERE id = ?1 AND is_deleted = FALSE")
             .bind(space_id)
@@ -168,6 +182,20 @@ impl SqliteDb {
         Ok(())
     }
 
+    /// Returns the note by its id.
+    ///
+    /// The dame as [SqliteDb::node_by_id] but returns the note even if deleted.
+    pub async fn absolute_note_by_id(note_id: Uuid, connection: &mut SqliteConnection) -> Result<Note, DbError> {
+        let note =
+            sqlx::query_as("SELECT id, text, created_at, updated_at, space_id, is_deleted FROM notes WHERE id = ?1")
+                .bind(note_id)
+                .fetch_one(&mut *connection)
+                .await?;
+
+        Ok(note)
+    }
+
+    /// Returns the note by its id. Returns an error if the node is deleted.
     pub async fn note_by_id(note_id: Uuid, connection: &mut SqliteConnection) -> Result<Note, DbError> {
         let note = sqlx::query_as("SELECT id, text, created_at, updated_at, space_id, is_deleted FROM notes WHERE id = ?1 AND is_deleted = FALSE")
             .bind(note_id)
@@ -232,6 +260,21 @@ impl SqliteDb {
         Ok(())
     }
 
+    /// Returns the file by its id.
+    ///
+    /// The same as [SqliteDb::file_by_id] but returns the file even if deleted.
+    pub async fn absolute_file_by_id(file_id: Uuid, connection: &mut SqliteConnection) -> Result<File, DbError> {
+        let file = sqlx::query_as(
+            "SELECT id, name, path, created_at, updated_at, is_deleted, is_uploaded FROM files WHERE id = ?1",
+        )
+        .bind(file_id)
+        .fetch_one(&mut *connection)
+        .await?;
+
+        Ok(file)
+    }
+
+    /// Returns the file by its id. Returns an error if the file is deleted.
     pub async fn file_by_id(file_id: Uuid, connection: &mut SqliteConnection) -> Result<File, DbError> {
         let file = sqlx::query_as(
             "SELECT id, name, path, created_at, updated_at, is_deleted, is_uploaded FROM files WHERE id = ?1 AND is_deleted = FALSE",

--- a/dataans/src-tauri/src/dataans/service/file.rs
+++ b/dataans/src-tauri/src/dataans/service/file.rs
@@ -150,7 +150,7 @@ impl<D: Db> FileService<D> {
         let image_data = clipboard.get_image()?;
 
         let id = Uuid::new_v4();
-        let name = format!("{}.png", Uuid::new_v4());
+        let name = format!("{id}.png");
 
         let image_path = self.files_path.join(&name);
 

--- a/dataans/src-tauri/src/dataans/sync/client.rs
+++ b/dataans/src-tauri/src/dataans/sync/client.rs
@@ -164,7 +164,12 @@ impl Client {
     pub async fn exists(&self, id: Uuid) -> Result<bool, SyncError> {
         let response = self
             .client
-            .get(self.sync_server.join("file/")?.join(&id.to_string())?)
+            .get(
+                self.sync_server
+                    .join("file/")?
+                    .join(&format!("{id}/"))?
+                    .join("exists")?,
+            )
             .send()
             .await?
             .error_for_status()?;

--- a/dataans/src-tauri/src/dataans/sync/client.rs
+++ b/dataans/src-tauri/src/dataans/sync/client.rs
@@ -117,7 +117,7 @@ impl Client {
     ///
     /// This method automatically encrypts provided operations.
     #[instrument(err, skip(self, operations))]
-    pub async fn upload_operations(&self, operations: &[&OperationRecord<'_>]) -> Result<(), SyncError> {
+    pub async fn upload_operations(&self, operations: &[OperationRecord<'_>]) -> Result<(), SyncError> {
         let operations = operations
             .iter()
             .map(|operation| {

--- a/dataans/src-tauri/src/dataans/sync/client.rs
+++ b/dataans/src-tauri/src/dataans/sync/client.rs
@@ -160,6 +160,18 @@ impl Client {
         Ok(())
     }
 
+    /// Checks whether the file with the given ID exists on the server.
+    pub async fn exists(&self, id: Uuid) -> Result<bool, SyncError> {
+        let response = self
+            .client
+            .get(self.sync_server.join("file/")?.join(&id.to_string())?)
+            .send()
+            .await?
+            .error_for_status()?;
+
+        Ok(response.json::<bool>().await?)
+    }
+
     /// Downloads the file from the server.
     ///
     /// The provided path must be absolute in the file system.

--- a/dataans/src-tauri/src/dataans/sync/mod.rs
+++ b/dataans/src-tauri/src/dataans/sync/mod.rs
@@ -227,6 +227,13 @@ impl<D: OperationDb> Synchronizer<D> {
                     SyncError::Event("failed to emit data event")
                 })?;
         } else {
+            // We need to improve this case in the future. Why do we even have it:
+            // When we accept the `CreateFile` operation from the sync server, we do not know if the file is already uploaded or not.
+            // Obviously, the file does not exist locally. Also, file's `is_uploaded` property is false by default.
+            // Here we try to download the file. But if the file is not found on the server, then [_there is nothing we can do_](https://knowyourmeme.com/memes/napoleon-there-is-nothing-we-can-do).
+
+            //
+            // TODO: improve.
             warn!(?file.id, ?file.path, "File does not exist locally and is not uploaded. Something weird happens here...");
             emitter
                 .emit(

--- a/dataans/src-tauri/src/dataans/sync/mod.rs
+++ b/dataans/src-tauri/src/dataans/sync/mod.rs
@@ -277,19 +277,6 @@ impl<D: OperationDb> Synchronizer<D> {
                         })?;
                 }
             }
-
-            //
-            // TODO: improve.
-            warn!(?file.id, ?file.path, "File does not exist locally and is not uploaded. Something weird happens here...");
-            emitter
-                .emit(
-                    DATA_EVENT,
-                    DataEvent::FileStatusUpdated(file.id.into(), FileStatus::NotExistAndNotUploaded),
-                )
-                .map_err(|err| {
-                    error!(?err, "Failed to emit data event");
-                    SyncError::Event("failed to emit data event")
-                })?;
         }
 
         Ok(())

--- a/doc/sync_server.md
+++ b/doc/sync_server.md
@@ -126,10 +126,10 @@ So, we can discard operations that belong to blocks with the same hashes. If eit
 
 After that, the app requests the server's notes starting from the end of the last discarded block. The same for local operations: the app selects local operation starting from the last discarded block.
 
-As a result, the app has two operation lists: local and remote. Both lists are sorted by timestamp. The app will compare them one by one and discard operations with the same id.
-This process stops when the app finds the two operations with different ids. Starting from this point, the rest of the local operations will be uploaded on the remote server, and the rest of the remote operations will be applied on the local database.
-Starting from this point, the app does not need to check other operations in lists, because it is guaranteed that their ids will be different.
-The app can safely stop comparing on the first operations pair with different ids.
+As a result, the app has two operation lists: local and remote. Both lists are sorted by timestamp. The app finds common operations for both lists.
+Then, these common operations are eliminated from local and remote operations lists. After that, we will have two lists with unique operations.
+
+The rest is an easy job. The app applies remote operations on a local database and uploads local operations.
 
 ### Conflict resolution
 


### PR DESCRIPTION
This PR fixes a bunch of bugs in the synchronization algorithm. There is a short description:

## Fixed remote operations applying

Sometimes we used to get the `sqlx` error about a non-existent row. It was happening because the app was searching only in notes/spaces with `is_deleted = FALSE`. It was wrong because it is possible to update the note on one device after it was deleted on another device.

If the note is updated after its deletion, then we should restore it and apply the changes.

## Fixed the `CreateFile` operation applying

Previously, we assumed that when we accept the `CreateFile` operation, it also means that the file is uploaded. But it is not necessarily true. The operation can be synced with the server before the actual file upload happens. For example, when file uploading fails but the operations uploading succeed, or when two concurrent sync processes are running.

## Improved file synchronization algorithm

Now, when the file is not uploaded and does not exist locally, we try to download it from the sync server anyway (see bug description above). Sometimes it can help. Otherwise, we just continue.

## Fixed the common operations elimination algorithm

At step 4 of the synchronization algorithm (https://github.com/TheBestTvarynka/Dataans/blob/e0b80622160b718b122dcd7b5cea0491e27b2a5c/dataans/src-tauri/src/dataans/sync/mod.rs#L46-L48), the app has lists of remote and local operations and needs to eliminate common operations from these lists.
Previously, the app compared IDs from two lists one by one, and stopped on two operations with different IDs. The assumption was that starting from this point, the app does not need to check other operations in lists, because it is guaranteed that their IDs will be different.

But, unfortunately, it is not true, so I reimplemented this part (https://github.com/TheBestTvarynka/Dataans/pull/156/commits/07d6a6244695ee37657fa41ef64516ca9d492010). I decided to keep it simple and used `HashSet` from `sts` and its `.intersection` method. Yes, it can be better and can be optimized (for example, using the [Longest Common Subsequence (LCS)](https://en.wikipedia.org/wiki/Longest_common_subsequence) algorithm), but I do not need it for now.

## Allow operation reuploading and reapplying existing operations

Now the user is allowed to upload the same operation twice. Also, the user is allowed to apply the same operation on the local database twice. In the last case, the app will just ignore the operation if it already exists. But the thing is, it will not return any errors (but will print a warning in logs).

It sounds absurd, but if you look at bugs above... I decided to allow it because who knows what will happen in the future. I believe this will help catch future bugs.