### PR TITLE
feat(front): note: implement images resizing;

### DIFF
--- a/dataans/src/notes/md_node/image.rs
+++ b/dataans/src/notes/md_node/image.rs
@@ -8,9 +8,9 @@
 /// ```not_rust
 /// =WIDTHxHEIGHT
 /// ```
-/// 
+///
 /// or
-/// 
+///
 /// ```not_rust
 /// =PERCENT%
 /// ```
@@ -33,11 +33,11 @@
 ///
 /// **Attention:** You cannot specify a relative image size for width and height.
 /// The following format is invalid:
-/// 
+///
 /// ```md
 /// ![=40%x60%](path/to/image.png)
 /// ```
-/// 
+///
 /// Why? Because it is hard to support such a behavior in CSS. Also, it is not a common use case.
 /// It's not worth the trouble.
 ///

--- a/dataans/src/notes/md_node/mod.rs
+++ b/dataans/src/notes/md_node/mod.rs
@@ -163,7 +163,7 @@ pub fn render_md_node(node: &Node, base_path: &str) -> AnyView {
             let alt = image.alt.clone();
             let style = parse_image_size(&alt);
             view! {
-                <img src=convert_file_src(&image.url, base_path) alt={alt} class="note-image" style={style} on:click=open_image />
+                <img src=convert_file_src(&image.url, base_path) alt={alt} class="note-image" style={style} on:click=open_image title={image.title.clone()} />
             }
         }
         .into_any(),


### PR DESCRIPTION
Originally, the MD does not allow resizing images. However, we use a small workaround to allow image resizing. The user can specify the image size in the alt text. The image size must meet the predefined format:

```not_rust
=WIDTHxHEIGHT
```

or

```not_rust
=PERCENT%
```

## Example

```md
Resize the image to 200x300 pixels:
![=200x300](path/to/image.png)

Resize the image to 100 pixels in width and auto height:
![=100x](path/to/image.png)

Resize the image to auto width and 150 pixels in height:
![=x150](path/to/image.png)

Resize the image to 20% of its original size:
![=20%](path/to/image.png)
```

**Attention:** You cannot specify a relative image size for width and height. The following format is invalid:

```md
![=40%x60%](path/to/image.png)
```

Why? Because it is hard to support such a behavior in CSS. Also, it is not a common use case.
It's not worth the trouble.

## Why ALT text?

Because it is not usually used for anything else in our app. We always expect the image to exist.
Even if the image does not exist, the alt text will be displayed instead.

## Image title

It turned out that MD supports image titles. Now, we render image titles too.

```md
![=66%](9cce0085-ae43-4180-a264-921867b60bec.png "Decrypted AP_REQ message")
```

Result:

<img width="961" height="259" alt="image" src="https://github.com/user-attachments/assets/b1a09e22-f605-4fbd-985a-b984f950d567" />

closes #174 