### PR TITLE
Fix cursor position after new line

### DIFF
--- a/dataans/src/common/textarea.rs
+++ b/dataans/src/common/textarea.rs
@@ -252,7 +252,7 @@ fn get_text_format_fn(event: KeyboardEvent) -> Option<TextFormatFn> {
             &move |pre_text, selected_text, after_text, _start| match parse_prev_line(&pre_text) {
                 LineType::None { trimmed } => {
                     let trimmed_len = trimmed.chars().count() as u32;
-                    let current = pre_text.len() as u32 + 1 + trimmed_len;
+                    let current = pre_text.chars().count() as u32 + 1 + trimmed_len;
                     (
                         format!("{pre_text}\n{trimmed}{selected_text}{after_text}"),
                         Some((current, current)),


### PR DESCRIPTION
# Issue I am trying to solve
My workflow:
- Using a lot of non-ascii characters
- a lot of new-lining in the middle of text

Each new line caused cursor to jump to the wrong position

https://github.com/user-attachments/assets/ee6bff75-5cdc-4212-bc5d-1e7adac88a52

# Solution
My solution is to calculate new position by calculating codepoints instead of bytes in string

https://github.com/user-attachments/assets/9d963f16-48a5-4bb2-a843-9f154527c7a4
