### PR TITLE
fix: image pasting from clipboard;

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,6 +190,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "windows-sys 0.60.2",
+ "wl-clipboard-rs",
  "x11rb",
 ]
 
@@ -2235,6 +2236,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2563,6 +2570,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -5311,6 +5324,17 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.1",
+]
 
 [[package]]
 name = "phf"
@@ -8706,6 +8730,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom",
+ "petgraph",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9198,6 +9233,76 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap 2.13.1",
  "semver",
+]
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fee64194ccd96bf648f42a65a7e589547096dfa702f7cadef84347b66ad164f9"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e6faa537fbb6c186cb9f1d41f2f811a4120d1b57ec61f50da451a0c5122bec"
+dependencies = [
+ "bitflags 2.11.0",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baeda9ffbcfc8cd6ddaade385eaf2393bd2115a69523c735f12242353c3df4f3"
+dependencies = [
+ "bitflags 2.11.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9597cdf02cf0c34cd5823786dce6b5ae8598f05c2daf5621b6e178d4f7345f3"
+dependencies = [
+ "bitflags 2.11.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5423e94b6a63e68e439803a3e153a9252d5ead12fd853334e2ad33997e3889e3"
+dependencies = [
+ "proc-macro2",
+ "quick-xml",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6dbfc3ac5ef974c92a2235805cc0114033018ae1290a72e474aa8b28cbbdfd"
+dependencies = [
+ "pkg-config",
 ]
 
 [[package]]
@@ -10030,6 +10135,24 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "wl-clipboard-rs"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix",
+ "thiserror 2.0.18",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
 ]
 
 [[package]]

--- a/dataans/src-tauri/Cargo.toml
+++ b/dataans/src-tauri/Cargo.toml
@@ -44,7 +44,7 @@ base64ct = "1.8"
 avatar_generator = { git = "https://gitlab.com/dataans/tools.git", rev = "0a3f1c526d86e223216ab0cb26afa076cfddc363", package = "image" }
 opener = { version = "0.8", features = ["reveal"] }
 image = "0.25"
-arboard = "3.6"
+arboard = { version = "3.6", features = ["wayland-data-control"] }
 syntect = "5.3"
 serde_json = "1"
 rand = "0.10"

--- a/dataans/src/common/textarea.rs
+++ b/dataans/src/common/textarea.rs
@@ -36,48 +36,40 @@ pub fn TextArea(
             .dyn_into::<web_sys::ClipboardEvent>()
             .expect("Event -> ClipboardEvent should not fail");
         if let Some(clipboard_data) = ev.clipboard_data() {
-            let types = clipboard_data.types();
-            let len = types.length();
-            if (0..len).any(|type_index| {
-                let ty = types
-                    .get(type_index)
-                    .as_string()
-                    .expect("MIME type JsValue should be string");
-                ty.to_ascii_lowercase().contains("files")
-            }) {
-                let toaster = toaster.clone();
+            let toaster = toaster.clone();
+
+            let mut text = text.get();
+            let id = elem_id.clone();
+            spawn_local(async move {
+                let Ok(image) = load_clipboard_image().await else {
+                    return;
+                };
 
                 ev.prevent_default();
-                let mut text = text.get();
-                let id = elem_id.clone();
-                spawn_local(async move {
-                    let image = try_exec!(load_clipboard_image().await, "Failed to load clipboard image", toaster);
-                    let image_path = try_exec!(
-                        image.path.to_str().ok_or("use UTF-8 valid paths"),
-                        "Image path is not a valid UTF-8 string",
-                        toaster
-                    );
 
-                    let text_area = document().get_element_by_id(&id).expect("Dom element should present");
-                    let text_area = text_area
-                        .dyn_into::<web_sys::HtmlTextAreaElement>()
-                        .expect("Element should be textarea");
+                let image_path = try_exec!(
+                    image.path.to_str().ok_or("use UTF-8 valid paths"),
+                    "Image path is not a valid UTF-8 string",
+                    toaster
+                );
 
-                    if let Some(start) = text_area.selection_start().expect("selection start error") {
-                        let start = start as usize;
-                        text = format!("{}![]({}){}", &text[0..start], &image_path, &text[start..]);
-                    } else {
-                        text.push_str("![](");
-                        text.push_str(image_path);
-                        text.push(')');
-                    }
+                let text_area = document().get_element_by_id(&id).expect("Dom element should present");
+                let text_area = text_area
+                    .dyn_into::<web_sys::HtmlTextAreaElement>()
+                    .expect("Element should be textarea");
 
-                    set_text.run((text,));
-                    set_disabled.set(false);
-                });
-            } else {
-                info!("No images to upload.");
-            }
+                if let Some(start) = text_area.selection_start().expect("selection start error") {
+                    let start = start as usize;
+                    text = format!("{}![]({}){}", &text[0..start], &image_path, &text[start..]);
+                } else {
+                    text.push_str("![](");
+                    text.push_str(image_path);
+                    text.push(')');
+                }
+
+                set_text.run((text,));
+                set_disabled.set(false);
+            });
         } else {
             info!("No clipboard data.");
         }

--- a/dataans/src/common/textarea.rs
+++ b/dataans/src/common/textarea.rs
@@ -35,7 +35,7 @@ pub fn TextArea(
         let ev = e
             .dyn_into::<web_sys::ClipboardEvent>()
             .expect("Event -> ClipboardEvent should not fail");
-        if let Some(clipboard_data) = ev.clipboard_data() {
+        if ev.clipboard_data().is_some() {
             let toaster = toaster.clone();
 
             let mut text = text.get();


### PR DESCRIPTION
I fixed image pasting from the clipboard in this PR.

## Problem

It did not work for two reasons:

1. The web API stopped returning the copied image in the file list. I tried all possible methods in the [`web_sys::DataTransfer`](docs.rs/web-sys/latest/web_sys/struct.DataTransfer.html). I tried to use the [`use_clipboard`](https://docs.rs/leptos-use/latest/leptos_use/fn.use_clipboard.html) helper, but it does not support images. It supports only text data.
2. Because I use KDE with the Wayland protocol, the `arboard` crate failed to load the image from the clipboard.

## Solution

1. I removed the code for the clipboard data type checking. Now it works more simply: it tries to paste the image; if that fails, it pastes the clipboard data as text.
2.  I enabled the `wayland-data-control` feature of the `arboard` crate. This feature prioritizes Wayland protocol over X11. It should not break X11-only desktops (but we will never know. If so, create an issue).